### PR TITLE
Release 1.6.0

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -18,4 +18,4 @@ services:
     host: function
     language: js  # Logic Apps aren't natively supported by azd yet. By using js, the logic app will be zipped and deployed.
 requiredVersions: 
-  azd: ">= 1.12.0"  # azd version 1.12.0 or later is required because of the use of the Bicep deployer() function
+  azd: ">= 1.17.0"  # azd version 1.17.0 or later is required because of the new bicep linter rule 'no-unused-imports'.

--- a/azure.yaml
+++ b/azure.yaml
@@ -2,7 +2,7 @@
 
 name: azure-integration-services-quickstart
 metadata:
-  template: tdd-azure-integration-services-quickstart@1.5.0
+  template: tdd-azure-integration-services-quickstart@1.6.0
 hooks:
   predown:
     - shell: pwsh

--- a/bicepconfig.json
+++ b/bicepconfig.json
@@ -54,6 +54,9 @@
         "no-unused-existing-resources": {
           "level": "error"
         },
+        "no-unused-imports": {
+          "level": "error"
+        },
         "no-unused-params": {
           "level": "error"
         },

--- a/infra/functions/naming-conventions.bicep
+++ b/infra/functions/naming-conventions.bicep
@@ -60,7 +60,7 @@ func removeHyphens(value string) string => replace(value, '-', '')
 // Sanitize the resource name by removing illegal characters and converting it to lower case.
 func sanitizeResourceName(value string) string => toLower(removeTrailingHyphen(removeColons(removeCommas(removeDots(removeSemicolons(removeUnderscores(removeWhiteSpaces(value))))))))
 
-func removeTrailingHyphen(value string) string => endsWith(value, '-') ? substring(value, 0, length(value)-1) : value
+func removeTrailingHyphen(value string) string => endsWith(value, '-') ? substring(value, 0, max(0, length(value)-1)) : value
 func removeColons(value string) string => replace(value, ':', '')
 func removeCommas(value string) string => replace(value, ',', '')
 func removeDots(value string) string => replace(value, '.', '')

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -10,8 +10,6 @@ targetScope = 'subscription'
 //=============================================================================
 
 import { getResourceName, getInstanceId } from './functions/naming-conventions.bicep'
-import * as settings from './types/settings.bicep'
-
 
 //=============================================================================
 // Parameters

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -110,7 +110,6 @@ resource resourceGroup 'Microsoft.Resources/resourceGroups@2024-07-01' = {
 }
 
 module keyVault 'modules/services/key-vault.bicep' = {
-  name: 'keyVault'
   scope: resourceGroup
   params: {
     location: location
@@ -120,7 +119,6 @@ module keyVault 'modules/services/key-vault.bicep' = {
 }
 
 module storageAccount 'modules/services/storage-account.bicep' = {
-  name: 'storageAccount'
   scope: resourceGroup
   params: {
     location: location
@@ -130,7 +128,6 @@ module storageAccount 'modules/services/storage-account.bicep' = {
 }
 
 module appInsights 'modules/services/app-insights.bicep' = {
-  name: 'appInsights'
   scope: resourceGroup
   params: {
     location: location
@@ -140,7 +137,6 @@ module appInsights 'modules/services/app-insights.bicep' = {
 }
 
 module eventHubsNamespace 'modules/services/event-hubs-namespace.bicep' = if (eventHubSettings != null) {
-  name: 'eventHubsNamespace'
   scope: resourceGroup
   params: {
     location: location
@@ -150,7 +146,6 @@ module eventHubsNamespace 'modules/services/event-hubs-namespace.bicep' = if (ev
 }
 
 module serviceBus 'modules/services/service-bus.bicep' = if (serviceBusSettings != null) {
-  name: 'serviceBus'
   scope: resourceGroup
   params: {
     location: location
@@ -160,7 +155,6 @@ module serviceBus 'modules/services/service-bus.bicep' = if (serviceBusSettings 
 }
 
 module apiManagement 'modules/services/api-management.bicep' = if (apiManagementSettings != null) {
-  name: 'apiManagement'
   scope: resourceGroup
   params: {
     location: location
@@ -181,7 +175,6 @@ module apiManagement 'modules/services/api-management.bicep' = if (apiManagement
 }
 
 module functionApp 'modules/services/function-app.bicep' = if (functionAppSettings != null) {
-  name: 'functionApp'
   scope: resourceGroup
   params: {
     location: location
@@ -204,7 +197,6 @@ module functionApp 'modules/services/function-app.bicep' = if (functionAppSettin
 }
 
 module logicApp 'modules/services/logic-app.bicep' = if (logicAppSettings != null) {
-  name: 'logicApp'
   scope: resourceGroup
   params: {
     location: location
@@ -227,7 +219,6 @@ module logicApp 'modules/services/logic-app.bicep' = if (logicAppSettings != nul
 }
 
 module assignRolesToDeployer 'modules/shared/assign-roles-to-principal.bicep' = {
-  name: 'assignRolesToDeployer'
   scope: resourceGroup
   params: {
     principalId: deployer().objectId
@@ -251,7 +242,6 @@ module assignRolesToDeployer 'modules/shared/assign-roles-to-principal.bicep' = 
 //=============================================================================
 
 module applicationResources 'modules/application/application.bicep' = if (includeApplicationInfraResources) {
-  name: 'applicationResources'
   scope: resourceGroup
   params: {
     apiManagementSettings: apiManagementSettings

--- a/infra/modules/application/application.bicep
+++ b/infra/modules/application/application.bicep
@@ -33,7 +33,6 @@ param storageAccountName string
 //=============================================================================
 
 module sampleApi 'sample-api/sample-api.bicep' = if (apiManagementSettings != null) {
-  name: 'sampleApi'
   params: {
     apiManagementServiceName: apiManagementSettings!.serviceName
     serviceBusSettings: serviceBusSettings
@@ -41,7 +40,6 @@ module sampleApi 'sample-api/sample-api.bicep' = if (apiManagementSettings != nu
 }
 
 module topicsAndSubscriptions 'service-bus/topics-and-subscriptions.bicep' = if (serviceBusSettings != null) {
-  name: 'topicsAndSubscriptions'
   params: {
     serviceBusSettings: serviceBusSettings!
     functionAppSettings: functionAppSettings
@@ -50,7 +48,6 @@ module topicsAndSubscriptions 'service-bus/topics-and-subscriptions.bicep' = if 
 }
 
 module storageAccount 'storage-account/storage-account.bicep' = {
-  name: 'storageAccount'
   params: {
     storageAccountName: storageAccountName
   }

--- a/infra/modules/services/api-management.bicep
+++ b/infra/modules/services/api-management.bicep
@@ -75,7 +75,6 @@ resource apimIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-
 }
 
 module assignRolesToApimUserAssignedIdentity '../shared/assign-roles-to-principal.bicep' = {
-  name: 'assignRolesToApimUserAssignedIdentity'
   params: {
     principalId: apimIdentity.properties.principalId
     principalType: 'ServicePrincipal'
@@ -111,7 +110,6 @@ resource apiManagementService 'Microsoft.ApiManagement/service@2024-06-01-previe
 // Assign roles to system-assigned identity of API Management
 
 module assignRolesToApimSystemAssignedIdentity '../shared/assign-roles-to-principal.bicep' = {
-  name: 'assignRolesToApimSystemAssignedIdentity'
   params: {
     principalId: apiManagementService.identity.principalId
     principalType: 'ServicePrincipal'

--- a/infra/modules/services/api-management.bicep
+++ b/infra/modules/services/api-management.bicep
@@ -53,7 +53,7 @@ resource appInsights 'Microsoft.Insights/components@2020-02-02' existing = {
   name: appInsightsName
 }
 
-resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+resource keyVault 'Microsoft.KeyVault/vaults@2024-11-01' existing = {
   name: keyVaultName
 }
 
@@ -166,7 +166,7 @@ resource apimInsightsDiagnostics 'Microsoft.ApiManagement/service/diagnostics@20
 
 // Store master subscription key in Key Vault
 
-resource apimMasterSubscriptionKeySecret 'Microsoft.KeyVault/vaults/secrets@2023-07-01' = {
+resource apimMasterSubscriptionKeySecret 'Microsoft.KeyVault/vaults/secrets@2024-11-01' = {
   name: 'apim-master-subscription-key'
   parent: keyVault
   properties: {

--- a/infra/modules/services/function-app.bicep
+++ b/infra/modules/services/function-app.bicep
@@ -116,7 +116,6 @@ resource functionAppIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2
 }
 
 module assignRolesToFunctionAppUserAssignedIdentity '../shared/assign-roles-to-principal.bicep' = {
-  name: 'assignRolesToFunctionAppUserAssignedIdentity'
   params: {
     principalId: functionAppIdentity.properties.principalId
     principalType: 'ServicePrincipal'
@@ -171,7 +170,6 @@ resource functionApp 'Microsoft.Web/sites@2024-04-01' = {
 // Assign roles to system-assigned identity of Function App
 
 module assignRolesToFunctionAppSystemAssignedIdentity '../shared/assign-roles-to-principal.bicep' = {
-  name: 'assignRolesToFunctionAppSystemAssignedIdentity'
   params: {
     principalId: functionApp.identity.principalId
     principalType: 'ServicePrincipal'
@@ -188,7 +186,6 @@ module assignRolesToFunctionAppSystemAssignedIdentity '../shared/assign-roles-to
 //        to prevent other (manually) created app settings from being removed.
 
 module setFunctionAppSettings '../shared/merge-app-settings.bicep' = {
-  name: 'setFunctionAppSettings'
   params: {
     siteName: functionAppSettings.functionAppName
     currentAppSettings: list('${functionApp.id}/config/appsettings', functionApp.apiVersion).properties

--- a/infra/modules/services/key-vault.bicep
+++ b/infra/modules/services/key-vault.bicep
@@ -25,7 +25,7 @@ param keyVaultName string
 
 // Key Vault (see also: https://learn.microsoft.com/en-us/azure/key-vault/secrets/quick-create-bicep?tabs=CLI)
 
-resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' = {
+resource keyVault 'Microsoft.KeyVault/vaults@2024-11-01' = {
   name: keyVaultName
   location: location
   tags: tags

--- a/infra/modules/services/logic-app.bicep
+++ b/infra/modules/services/logic-app.bicep
@@ -119,7 +119,6 @@ resource logicAppIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024
 }
 
 module assignRolesToLogicAppUserAssignedIdentity '../shared/assign-roles-to-principal.bicep' = {
-  name: 'assignRolesToLogicAppUserAssignedIdentity'
   params: {
     principalId: logicAppIdentity.properties.principalId
     principalType: 'ServicePrincipal'
@@ -176,7 +175,6 @@ resource logicApp 'Microsoft.Web/sites@2024-04-01' = {
 // Assign roles to system-assigned identity of Logic App
 
 module assignRolesToLogicAppSystemAssignedIdentity '../shared/assign-roles-to-principal.bicep' = {
-  name: 'assignRolesToLogicAppSystemAssignedIdentity'
   params: {
     principalId: logicApp.identity.principalId
     principalType: 'ServicePrincipal'
@@ -193,7 +191,6 @@ module assignRolesToLogicAppSystemAssignedIdentity '../shared/assign-roles-to-pr
 //        to prevent other (manually) created app settings from being removed.
 
 module setLogicAppSettings '../shared/merge-app-settings.bicep' = {
-  name: 'setLogicAppSettings'
   params: {
     siteName: logicAppSettings.logicAppName
     currentAppSettings: list('${logicApp.id}/config/appsettings', logicApp.apiVersion).properties

--- a/infra/modules/shared/assign-roles-to-principal.bicep
+++ b/infra/modules/shared/assign-roles-to-principal.bicep
@@ -70,7 +70,7 @@ resource eventHubsNamespace 'Microsoft.EventHub/namespaces@2024-01-01' existing 
   name: eventHubSettings!.namespaceName
 }
 
-resource keyVault 'Microsoft.KeyVault/vaults@2023-07-01' existing = {
+resource keyVault 'Microsoft.KeyVault/vaults@2024-11-01' existing = {
   name: keyVaultName
 }
 


### PR DESCRIPTION
# Changes
- **Updated Key Vault API Version**: Now uses `2024-11-01` for improved compatibility and features.
- **Added Bicep Linter Rule**: Enabled the `no-unused-imports` rule for cleaner Bicep templates.
- **Updated Required azd Version**: Minimum required Azure Developer CLI version set to `1.17.0` to support the new linter rule.
- **Removed Unused Imports**: Cleaned up unused import of `settings.bicep` from `main.bicep`.
- **Removed Bicep Module Names**: These are now optional as of Bicep v0.34.1.
- **Naming Convention Fixes**: Addressed warning related to minimum value constraints.