### PR TITLE
Use roleDefinitions function when assigning roles

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -14,4 +14,4 @@ services:
     host: function
     language: js # Logic Apps aren't natively supported by azd yet. By using js, the logic app will be zipped and deployed.
 requiredVersions:
-  azd: ">= 1.19.0" # azd version 1.19.0 or higher is required because older versions have issue in Azure Cloud Shell.
+  azd: ">= 1.23.15" # azd version 1.23.15 or higher is required because we're using features from Bicep 0.42.1.

--- a/bicepconfig.json
+++ b/bicepconfig.json
@@ -101,7 +101,7 @@
           "level": "warning"
         },
         "use-resource-id-functions": {
-          "level": "warning"
+          "level": "error"
         },
         "use-resource-symbol-reference": {
           "level": "error"

--- a/bicepconfig.json
+++ b/bicepconfig.json
@@ -101,7 +101,7 @@
           "level": "warning"
         },
         "use-resource-id-functions": {
-          "level": "error"
+          "level": "warning"
         },
         "use-resource-symbol-reference": {
           "level": "error"

--- a/infra/modules/shared/assign-roles-to-principal.bicep
+++ b/infra/modules/shared/assign-roles-to-principal.bicep
@@ -1,5 +1,5 @@
 //=============================================================================
-// Assign roles to principal on Application Insights, Key Vault, Service Bus, 
+// Assign roles to principal on Application Insights, Key Vault, Service Bus,
 // Storage Account and Event Hubs namespace
 //=============================================================================
 
@@ -42,29 +42,27 @@ param storageAccountName string
 //=============================================================================
 
 var eventHubRoles string[] = [
-  'a638d3c7-ab3a-418d-83e6-5f17a39d4fde' // Azure Event Hubs Data Receiver
-  '2b629674-e913-4c01-ae53-ef4638d8f975' // Azure Event Hubs Data Sender
+  'Azure Event Hubs Data Receiver'
+  'Azure Event Hubs Data Sender'
 ]
 
-var keyVaultRole string = isAdmin
-  ? '00482a5a-887f-4fb3-b363-3b7fe8e74483' // Key Vault Administrator
-  : '4633458b-17de-408a-b874-0445c86b69e6' // Key Vault Secrets User
+var keyVaultRole string = isAdmin ? 'Key Vault Administrator' : 'Key Vault Secrets User'
 
 var serviceBusRoles string[] = [
-  '4f6d3b9b-027b-4f4c-9142-0e5a2a2247e0' // Azure Service Bus Data Receiver
-  '69a216fc-b8fb-44d8-bc22-1f3c2cd27a39' // Azure Service Bus Data Sender
+  'Azure Service Bus Data Receiver'
+  'Azure Service Bus Data Sender'
 ]
 
 var storageAccountRoles string[] = [
-  'ba92f5b4-2d11-453d-a403-e96b0029c9fe' // Storage Blob Data Contributor
+  'Storage Blob Data Contributor'
   isAdmin
-    ? '69566ab7-960f-475b-8e7c-b3118f30c6bd' // Storage File Data Privileged Contributor (is able to browse file shares in Azure Portal)
-    : '0c867c2a-1d8c-454a-a3db-ab2ea1bdc8bb' // Storage File Data SMB Share Contributor
-  '974c5e8b-45b9-4653-ba55-5f855dd0fb88' // Storage Queue Data Contributor
-  '0a9a7e1f-b9d0-4cc4-a60d-0319b160aaa3' // Storage Table Data Contributor
+    ? 'Storage File Data Privileged Contributor' // is able to browse file shares in Azure Portal
+    : 'Storage File Data SMB Share Contributor'
+  'Storage Queue Data Contributor'
+  'Storage Table Data Contributor'
 ]
 
-var monitoringMetricsPublisher string = '3913510d-42f4-4e42-8a64-420c390055eb' // Monitoring Metrics Publisher
+var monitoringMetricsPublisher string = 'Monitoring Metrics Publisher'
 
 //=============================================================================
 // Existing Resources
@@ -100,11 +98,11 @@ resource assignAppInsightRolesToPrincipal 'Microsoft.Authorization/roleAssignmen
   name: guid(
     principalId,
     appInsights.id,
-    subscriptionResourceId('Microsoft.Authorization/roleDefinitions', monitoringMetricsPublisher)
+    monitoringMetricsPublisher
   )
   scope: appInsights
   properties: {
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', monitoringMetricsPublisher)
+    roleDefinitionId: roleDefinitions(monitoringMetricsPublisher).id
     principalId: principalId
     principalType: principalType
   }
@@ -117,11 +115,11 @@ resource assignRolesOnEventHubNamespaceToPrincipal 'Microsoft.Authorization/role
     name: guid(
       principalId,
       eventHubsNamespace.id,
-      subscriptionResourceId('Microsoft.Authorization/roleDefinitions', role)
+      roleDefinitions(role).id
     )
     scope: eventHubsNamespace
     properties: {
-      roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', role)
+      roleDefinitionId: roleDefinitions(role).id
       principalId: principalId
       principalType: principalType
     }
@@ -131,10 +129,10 @@ resource assignRolesOnEventHubNamespaceToPrincipal 'Microsoft.Authorization/role
 // Assign role on Key Vault to the principal
 
 resource assignRolesOnKeyVaultToPrincipal 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(principalId, keyVault.id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', keyVaultRole))
+  name: guid(principalId, keyVault.id, roleDefinitions(keyVaultRole).id)
   scope: keyVault
   properties: {
-    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', keyVaultRole)
+    roleDefinitionId: roleDefinitions(keyVaultRole).id
     principalId: principalId
     principalType: principalType
   }
@@ -147,11 +145,11 @@ resource assignRolesOnServiceBusToPrincipal 'Microsoft.Authorization/roleAssignm
     name: guid(
       principalId,
       serviceBusNamespace.id,
-      subscriptionResourceId('Microsoft.Authorization/roleDefinitions', role)
+      roleDefinitions(role).id
     )
     scope: serviceBusNamespace
     properties: {
-      roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', role)
+      roleDefinitionId: roleDefinitions(role).id
       principalId: principalId
       principalType: principalType
     }
@@ -162,10 +160,10 @@ resource assignRolesOnServiceBusToPrincipal 'Microsoft.Authorization/roleAssignm
 
 resource assignRolesOnStorageAccountToPrincipal 'Microsoft.Authorization/roleAssignments@2022-04-01' = [
   for role in storageAccountRoles: {
-    name: guid(principalId, storageAccount.id, subscriptionResourceId('Microsoft.Authorization/roleDefinitions', role))
+    name: guid(principalId, storageAccount.id, roleDefinitions(role).id)
     scope: storageAccount
     properties: {
-      roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', role)
+      roleDefinitionId: roleDefinitions(role).id
       principalId: principalId
       principalType: principalType
     }

--- a/infra/modules/shared/assign-roles-to-principal.bicep
+++ b/infra/modules/shared/assign-roles-to-principal.bicep
@@ -98,6 +98,7 @@ resource assignAppInsightRolesToPrincipal 'Microsoft.Authorization/roleAssignmen
   name: guid(principalId, appInsights.id, monitoringMetricsPublisher)
   scope: appInsights
   properties: {
+    #disable-next-line use-resource-id-functions
     roleDefinitionId: roleDefinitions(monitoringMetricsPublisher).id
     principalId: principalId
     principalType: principalType
@@ -111,6 +112,7 @@ resource assignRolesOnEventHubNamespaceToPrincipal 'Microsoft.Authorization/role
     name: guid(principalId, eventHubsNamespace.id, role)
     scope: eventHubsNamespace
     properties: {
+      #disable-next-line use-resource-id-functions
       roleDefinitionId: roleDefinitions(role).id
       principalId: principalId
       principalType: principalType
@@ -124,6 +126,7 @@ resource assignRolesOnKeyVaultToPrincipal 'Microsoft.Authorization/roleAssignmen
   name: guid(principalId, keyVault.id, keyVaultRole)
   scope: keyVault
   properties: {
+    #disable-next-line use-resource-id-functions
     roleDefinitionId: roleDefinitions(keyVaultRole).id
     principalId: principalId
     principalType: principalType
@@ -137,6 +140,7 @@ resource assignRolesOnServiceBusToPrincipal 'Microsoft.Authorization/roleAssignm
     name: guid(principalId, serviceBusNamespace.id, role)
     scope: serviceBusNamespace
     properties: {
+      #disable-next-line use-resource-id-functions
       roleDefinitionId: roleDefinitions(role).id
       principalId: principalId
       principalType: principalType
@@ -151,6 +155,7 @@ resource assignRolesOnStorageAccountToPrincipal 'Microsoft.Authorization/roleAss
     name: guid(principalId, storageAccount.id, role)
     scope: storageAccount
     properties: {
+      #disable-next-line use-resource-id-functions
       roleDefinitionId: roleDefinitions(role).id
       principalId: principalId
       principalType: principalType

--- a/infra/modules/shared/assign-roles-to-principal.bicep
+++ b/infra/modules/shared/assign-roles-to-principal.bicep
@@ -95,7 +95,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2025-08-01' existing 
 // Assign role Application Insights to the principal
 
 resource assignAppInsightRolesToPrincipal 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(principalId, appInsights.id, monitoringMetricsPublisher)
+  name: guid(principalId, appInsights.id, roleDefinitions(monitoringMetricsPublisher).id)
   scope: appInsights
   properties: {
     #disable-next-line use-resource-id-functions
@@ -109,7 +109,7 @@ resource assignAppInsightRolesToPrincipal 'Microsoft.Authorization/roleAssignmen
 
 resource assignRolesOnEventHubNamespaceToPrincipal 'Microsoft.Authorization/roleAssignments@2022-04-01' = [
   for role in eventHubRoles: if (eventHubSettings != null) {
-    name: guid(principalId, eventHubsNamespace.id, role)
+    name: guid(principalId, eventHubsNamespace.id, roleDefinitions(role).id)
     scope: eventHubsNamespace
     properties: {
       #disable-next-line use-resource-id-functions
@@ -123,7 +123,7 @@ resource assignRolesOnEventHubNamespaceToPrincipal 'Microsoft.Authorization/role
 // Assign role on Key Vault to the principal
 
 resource assignRolesOnKeyVaultToPrincipal 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(principalId, keyVault.id, keyVaultRole)
+  name: guid(principalId, keyVault.id, roleDefinitions(keyVaultRole).id)
   scope: keyVault
   properties: {
     #disable-next-line use-resource-id-functions
@@ -137,7 +137,7 @@ resource assignRolesOnKeyVaultToPrincipal 'Microsoft.Authorization/roleAssignmen
 
 resource assignRolesOnServiceBusToPrincipal 'Microsoft.Authorization/roleAssignments@2022-04-01' = [
   for role in serviceBusRoles: if (serviceBusSettings != null) {
-    name: guid(principalId, serviceBusNamespace.id, role)
+    name: guid(principalId, serviceBusNamespace.id, roleDefinitions(role).id)
     scope: serviceBusNamespace
     properties: {
       #disable-next-line use-resource-id-functions
@@ -152,7 +152,7 @@ resource assignRolesOnServiceBusToPrincipal 'Microsoft.Authorization/roleAssignm
 
 resource assignRolesOnStorageAccountToPrincipal 'Microsoft.Authorization/roleAssignments@2022-04-01' = [
   for role in storageAccountRoles: {
-    name: guid(principalId, storageAccount.id, role)
+    name: guid(principalId, storageAccount.id, roleDefinitions(role).id)
     scope: storageAccount
     properties: {
       #disable-next-line use-resource-id-functions

--- a/infra/modules/shared/assign-roles-to-principal.bicep
+++ b/infra/modules/shared/assign-roles-to-principal.bicep
@@ -95,11 +95,7 @@ resource storageAccount 'Microsoft.Storage/storageAccounts@2025-08-01' existing 
 // Assign role Application Insights to the principal
 
 resource assignAppInsightRolesToPrincipal 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(
-    principalId,
-    appInsights.id,
-    monitoringMetricsPublisher
-  )
+  name: guid(principalId, appInsights.id, monitoringMetricsPublisher)
   scope: appInsights
   properties: {
     roleDefinitionId: roleDefinitions(monitoringMetricsPublisher).id
@@ -112,11 +108,7 @@ resource assignAppInsightRolesToPrincipal 'Microsoft.Authorization/roleAssignmen
 
 resource assignRolesOnEventHubNamespaceToPrincipal 'Microsoft.Authorization/roleAssignments@2022-04-01' = [
   for role in eventHubRoles: if (eventHubSettings != null) {
-    name: guid(
-      principalId,
-      eventHubsNamespace.id,
-      roleDefinitions(role).id
-    )
+    name: guid(principalId, eventHubsNamespace.id, role)
     scope: eventHubsNamespace
     properties: {
       roleDefinitionId: roleDefinitions(role).id
@@ -129,7 +121,7 @@ resource assignRolesOnEventHubNamespaceToPrincipal 'Microsoft.Authorization/role
 // Assign role on Key Vault to the principal
 
 resource assignRolesOnKeyVaultToPrincipal 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
-  name: guid(principalId, keyVault.id, roleDefinitions(keyVaultRole).id)
+  name: guid(principalId, keyVault.id, keyVaultRole)
   scope: keyVault
   properties: {
     roleDefinitionId: roleDefinitions(keyVaultRole).id
@@ -142,11 +134,7 @@ resource assignRolesOnKeyVaultToPrincipal 'Microsoft.Authorization/roleAssignmen
 
 resource assignRolesOnServiceBusToPrincipal 'Microsoft.Authorization/roleAssignments@2022-04-01' = [
   for role in serviceBusRoles: if (serviceBusSettings != null) {
-    name: guid(
-      principalId,
-      serviceBusNamespace.id,
-      roleDefinitions(role).id
-    )
+    name: guid(principalId, serviceBusNamespace.id, role)
     scope: serviceBusNamespace
     properties: {
       roleDefinitionId: roleDefinitions(role).id
@@ -160,7 +148,7 @@ resource assignRolesOnServiceBusToPrincipal 'Microsoft.Authorization/roleAssignm
 
 resource assignRolesOnStorageAccountToPrincipal 'Microsoft.Authorization/roleAssignments@2022-04-01' = [
   for role in storageAccountRoles: {
-    name: guid(principalId, storageAccount.id, roleDefinitions(role).id)
+    name: guid(principalId, storageAccount.id, role)
     scope: storageAccount
     properties: {
       roleDefinitionId: roleDefinitions(role).id


### PR DESCRIPTION
Had to suppress `use-resource-id-functions` linter rule because using `roleDefinitions` doesn't (yet) comply with this rule.